### PR TITLE
Fix Windows builds by removing OpenSSL dependency and upload Bazel test artifacts in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,10 +6,12 @@ build:windows --cxxopt=/std:c++latest
 build:windows --cxxopt=/DUNICODE
 build:windows --cxxopt=/D_UNICODE
 build:windows --cxxopt=/D_WIN32_WINNT=0x0600
+build:windows --cxxopt=/DWIN32_LEAN_AND_MEAN
 build:clang-cl --cxxopt=/std:c++latest # MSVC's clang frontend takes MSVC-style flags
 build:clang-cl --cxxopt=/DUNICODE
 build:clang-cl --cxxopt=/D_UNICODE
 build:clang-cl --cxxopt=/D_WIN32_WINNT=0x0600
+build:clang-cl --cxxopt=/DWIN32_LEAN_AND_MEAN
 
 # This warning is low-value and triggers when adding an asio dependency.
 build:linux --cxxopt=-Wno-unused-local-typedef

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: bazel-testlogs
+          name: bazel-testlogs-${{ github.job }}
           path: bazel-testlogs/**/test.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,10 @@ jobs:
 
       - name: Test
         run: bazelisk test //...
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bazel-testlogs
+          path: bazel-testlogs/**/test.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bazel-testlogs-${{ github.job }}
           path: bazel-testlogs/**/test.xml

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ version_ext = use_extension("//:version.bzl", "version_extension")
 use_repo(version_ext, "birch_version")
 
 bazel_dep(name = "abseil-cpp", version = "20260107.1")
-bazel_dep(name = "asio", version = "1.34.2.bcr.0")
+bazel_dep(name = "asio", version = "1.34.2.bcr.1")
 bazel_dep(name = "aspect_rules_lint", version = "2.5.2")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -19,8 +19,8 @@
     "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
     "https://bcr.bazel.build/modules/apple_support/1.24.1/MODULE.bazel": "f46e8ddad60aef170ee92b2f3d00ef66c147ceafea68b6877cb45bd91737f5f8",
     "https://bcr.bazel.build/modules/apple_support/1.24.1/source.json": "cf725267cbacc5f028ef13bb77e7f2c2e0066923a4dab1025e4a0511b1ed258a",
-    "https://bcr.bazel.build/modules/asio/1.34.2.bcr.0/MODULE.bazel": "ada5fbcb526e1595846e6da3799c535f5e3a39122cdc9960a030490b9489e9e9",
-    "https://bcr.bazel.build/modules/asio/1.34.2.bcr.0/source.json": "b909cb39097eaef9dc2f647003957db4b54040e02e7d86888d446157e427065c",
+    "https://bcr.bazel.build/modules/asio/1.34.2.bcr.1/MODULE.bazel": "2f0d982ed23112b0446d5b74ef271bb7f79228261ccc71243d12d9a1baffbdcc",
+    "https://bcr.bazel.build/modules/asio/1.34.2.bcr.1/source.json": "32133cbe6a3cc999a585331ebd14ab79ff5b2ad25c7d048bef382e8fa5b3e19b",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.42.2/MODULE.bazel": "2e0d8ab25c57a14f56ace1c8e881b69050417ff91b2fb7718dc00d201f3c3478",
@@ -271,7 +271,7 @@
   "moduleExtensions": {
     "//:version.bzl%version_extension": {
       "general": {
-        "bzlTransitiveDigest": "Vl63gdwoQns5Ha3hdnD6xDw36e/otPYGLPj5+mp1IjM=",
+        "bzlTransitiveDigest": "TCmLkVN3DsixKlOxpcYGTREJZU64gLVjbHlF/hFqPQA=",
         "usagesDigest": "CFO8MEA72LVNcgKPN2Sb/3D30gtOeZDEZGoMlw6xLvo=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/config/FileConfigDataSourceTest.cc
+++ b/config/FileConfigDataSourceTest.cc
@@ -21,6 +21,7 @@
 #include <fstream>
 
 #include "absl/status/status.h"
+#include "absl/status/status_matchers.h"
 #include "gtest/gtest.h"
 
 #include "util/IFileWatcher.h"
@@ -35,7 +36,7 @@ protected:
     void SetUp() override
     {
         auto status = birch::util::InitializeGlobalFileWatcher();
-        ASSERT_TRUE(status.ok());
+        ABSL_ASSERT_OK(status);
         m_path = std::filesystem::path(testing::TempDir()) / "config.toml";
 
         std::ofstream os(m_path);
@@ -51,7 +52,7 @@ protected:
 TEST_F(FileConfigDataSourceTest, CreateFromFileAcceptsAbsolutePath)
 {
     auto source = FileConfigDataSource::CreateFromFile(std::filesystem::path(m_path));
-    ASSERT_TRUE(source.ok());
+    ABSL_EXPECT_OK(source);
     EXPECT_NE(*source, nullptr);
 }
 
@@ -60,7 +61,7 @@ TEST_F(FileConfigDataSourceTest, ReadReturnsFileContents)
     FileConfigDataSource source(m_path);
     auto contents = source.Read();
 
-    ASSERT_TRUE(contents.ok());
+    ABSL_EXPECT_OK(contents);
     EXPECT_EQ(*contents, "server_name = \"irc.example.com\"\n");
 }
 

--- a/server/AsioConnection.cc
+++ b/server/AsioConnection.cc
@@ -51,6 +51,12 @@ AsioConnection::AsioConnection(ConnId connId, tcp::socket&& socket)
     , m_socket{std::move(socket)}
     , m_strand{asio::make_strand(m_socket.get_executor())}
     , m_writeQueue{m_strand, kWriteQueueDefaultCapacity}
+    , m_message{}
+    , m_parser{}
+    , m_buffer{}
+    , m_serializer{}
+    , m_writeBuffer{}
+    , m_observers{}
 {
 }
 

--- a/server/BUILD
+++ b/server/BUILD
@@ -26,10 +26,13 @@ cc_library(
     name = "message_parser",
     srcs = ["MessageParser.cc"],
     hdrs = ["MessageParser.h"],
+    local_defines = [
+        "WIN32_LEAN_AND_MEAN",
+    ],
     deps = [
-        "message",
+        ":message",
         "@abseil-cpp//absl/strings",
-        "@asio",
+        "@asio//:asio_no_openssl",
     ],
 )
 
@@ -91,7 +94,7 @@ cc_library(
         ":message_serializer",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
-        "@asio",
+        "@asio//:asio_no_openssl",
     ],
 )
 
@@ -152,6 +155,6 @@ cc_library(
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",
-        "@asio",
+        "@asio//:asio_no_openssl",
     ],
 )

--- a/server/Server.cc
+++ b/server/Server.cc
@@ -17,11 +17,10 @@
 
 #include "Server.h"
 
-#include <signal.h>
-
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <csignal>
 #include <memory>
 #include <limits>
 #include <optional>
@@ -35,7 +34,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 
-#include <asio/ssl.hpp>
+#include <asio/awaitable.hpp>
 #include <asio.hpp>
 
 #include "server/AsioConnection.h"
@@ -49,7 +48,13 @@ constexpr const auto kTerminalSignals = std::array {
 };
 
 constexpr const auto kReloadSignals = std::array {
+#if defined(SIGBREAK)
+    SIGBREAK,
+#endif
+
+#if defined(SIGHUP)
     SIGHUP,
+#endif
 };
 
 struct ServerConfigData

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -5,12 +5,14 @@ format_multirun(name = "format")
 
 cc_library(
     name = "test_main",
+    testonly = True,
     srcs = ["TestMain.cc"],
     deps = [
         "@abseil-cpp//absl/debugging:failure_signal_handler",
         "@abseil-cpp//absl/debugging:symbolize",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:initialize",
+        "@abseil-cpp//absl/status:status_matchers",
         "@googletest//:gtest",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
The BCR OpenSSL dependency is broken on Windows, so this PR removes that dependency path for now (we can revisit with BoringSSL or another approach later).

Additionally, CI now uploads Bazel JUnit XML test artifacts from `bazel-testlogs/**/test.xml` using `actions/upload-artifact` (with `if: always()`), so failing test reports are preserved for debugging.